### PR TITLE
clib: Add utility array functions to c_hash_table_t.

### DIFF
--- a/clib/chashtable.c
+++ b/clib/chashtable.c
@@ -298,6 +298,25 @@ c_hash_table_get_keys(c_hash_table_t *hash)
     return c_llist_reverse(rv);
 }
 
+void **
+c_hash_table_get_keys_array(c_hash_table_t *hash)
+{
+    c_hash_table_iter_t iter;
+    void **keys = c_new (void*, hash->in_use);
+    void *key;
+    int i = 0;
+
+    c_hash_table_iter_init(&iter, hash);
+
+    while (c_hash_table_iter_next(&iter, &key, NULL))
+    {
+        keys[i] = key;
+        i++;
+    }
+
+    return keys;
+}
+
 c_llist_t *
 c_hash_table_get_values(c_hash_table_t *hash)
 {
@@ -312,6 +331,26 @@ c_hash_table_get_values(c_hash_table_t *hash)
 
     return c_llist_reverse(rv);
 }
+
+void **
+c_hash_table_get_values_array(c_hash_table_t *hash)
+{
+    c_hash_table_iter_t iter;
+    void **values = c_new (void*, hash->in_use);
+    void *value;
+    int i = 0;
+
+    c_hash_table_iter_init(&iter, hash);
+
+    while (c_hash_table_iter_next(&iter, NULL, &value))
+    {
+        values[i] = value;
+        i++;
+    }
+
+    return values;
+}
+
 
 unsigned int
 c_hash_table_size(c_hash_table_t *hash)

--- a/clib/clib.h
+++ b/clib/clib.h
@@ -794,7 +794,9 @@ void c_hash_table_insert_replace(c_hash_table_t *hash,
                                  bool replace);
 unsigned int c_hash_table_size(c_hash_table_t *hash);
 c_llist_t *c_hash_table_get_keys(c_hash_table_t *hash);
+void **c_hash_table_get_keys_array(c_hash_table_t *hash);
 c_llist_t *c_hash_table_get_values(c_hash_table_t *hash);
+void **c_hash_table_get_values_array(c_hash_table_t *hash);
 void *c_hash_table_lookup(c_hash_table_t *hash, const void *key);
 bool c_hash_table_lookup_extended(c_hash_table_t *hash,
                                   const void *key,


### PR DESCRIPTION
These two functions return either the values or keys of the
array in the form of 2D void pointers.
